### PR TITLE
adds ARTIFACT_URL env variable to arroyo-compiler-service command

### DIFF
--- a/developing/dev-setup.mdx
+++ b/developing/dev-setup.mdx
@@ -121,7 +121,7 @@ The api serves the frontend on http://localhost:8000 and provides a GRPC server 
 ### arroyo-compiler-service
 Start this service with
 ```bash
-OUTPUT_DIR=target  cargo run --bin arroyo-compiler-service start
+OUTPUT_DIR=target ARTIFACT_URL=file:///tmp/artifacts  cargo run --bin arroyo-compiler-service start
 ```
 The compiler service compiles the custom crate for each pipeline.
 Because Rust can take a while to compile, it reuses the same directory across compilations.


### PR DESCRIPTION
When trying to run arroyo locally, I had to explicitly set the `ARTIFACT_URL` environment variable in order to get `arroyo-compiler-service` running. (I believe this is due to [the added support for GCS and S3-compatible storage](https://github.com/ArroyoSystems/arroyo/pull/296).)

I have set it to `file:///tmp/artifacts`, which allows the service to start-- and because I am guessing that in development these files are not essential to persist.