### PR TITLE
Fix typo in reference to Cloudflare R2

### DIFF
--- a/architecture.mdx
+++ b/architecture.mdx
@@ -89,7 +89,7 @@ power the API and Web UI. Two databases are supported, with different scalabilit
 Arroyo relies on remote storage to store checkpoints so that pipelines can be recovered in case of failure or
 if they need to be rescaled or rescheduled. Local directories and remote object stores are supported;
 the former typically just for development and testing, while production use cases will use the latter. S3 (Amazon), GCS (Google Cloud),
-and ABS (Azure) are supported, as are alternative S3-compatible stores like Minio, Cloudflare R3, and
+and ABS (Azure) are supported, as are alternative S3-compatible stores like Minio, Cloudflare R2, and
 Backblaze B2.
 
 ## Job State Machine


### PR DESCRIPTION
It's a common mistake, but the product name is R2 :)