### PR TITLE
adds azure storage examples and environment variable specifications

### DIFF
--- a/deployment/overview.mdx
+++ b/deployment/overview.mdx
@@ -51,3 +51,36 @@ these, for example:
 * `file:///my/local/filesystem`
 * `/my/local/filesystem`
 * `gs://my-gcs-bucket`
+* `https://mystorageaccount.blob.core.windows.net/my-bucket/path`
+* `https://mystorageaccount.dfs.core.windows.net/my-bucket/path`
+* `abfs://my-container@mystorageaccount.dfs.core.windows.net/path`
+
+Authentication with the underlying storage provider is usually expected through environment variables corresponding
+to the cloud provider:
+
+| Provider | Environment Variable | Description |
+| ----- | ----------- | ------- |
+| AWS | `AWS_ACCESS_KEY_ID` | access_key_id |
+| AWS | `AWS_SECRET_ACCESS_KEY` | secret_access_key |
+| AWS | `AWS_DEFAULT_REGION` | Region |
+| AWS | `AWS_ENDPOINT` | Endpoint |
+| AWS | `AWS_SESSION_TOKEN` | Token |
+| AWS | `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` | <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html> |
+| AWS | `AWS_CONTAINER_CREDENTIALS_FULL_URI` | <https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html> |
+| AWS | `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` | <https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html> |
+| AWS | `AWS_ALLOW_HTTP` | Set to "true" to permit HTTP connections without TLS |
+| AWS | `AWS_REQUEST_PAYER` | Set to "true" to permit operations on requester-pays buckets |
+| Azure | AZURE_STORAGE_ACCOUNT_NAME | Storage account name |
+| Azure | AZURE_STORAGE_ACCOUNT_KEY | Storage account master key |
+| Azure | AZURE_STORAGE_ACCESS_KEY | Alias for AZURE_STORAGE_ACCOUNT_KEY |
+| Azure | AZURE_STORAGE_CLIENT_ID | Client id for service principal authorization |
+| Azure | AZURE_STORAGE_CLIENT_SECRET | Client secret for service principal authorization |
+| Azure | AZURE_STORAGE_TENANT_ID | Tenant id used in oauth flows |
+| GCS | `GOOGLE_SERVICE_ACCOUNT` | Location of service account file |
+| GCS | `GOOGLE_SERVICE_ACCOUNT_PATH` | (Alias) Location of service account file |
+| GCS | `SERVICE_ACCOUNT` | (Alias) Location of service account file |
+| GCS | `GOOGLE_SERVICE_ACCOUNT_KEY` | JSON serialized service account key |
+| GCS | `GOOGLE_BUCKET` | Bucket name |
+| GCS | `GOOGLE_BUCKET_NAME` | (Alias) bucket name |
+| R2 | `R2_ACCESS_KEY_ID` | access_key_id |
+| R2 | `R2_SECRET_ACCESS_KEY` | secret_access_key |


### PR DESCRIPTION
To go with https://github.com/ArroyoSystems/arroyo/pull/923, figured it might be nice to have some examples of the expected environment variables; most users should be familiar with the expected cloud providers, but it doesn't hurt to make things explicit.